### PR TITLE
feat: v0.3.0 - Multi-session support, notification control, and UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ package-lock.json
 .luarc.json
 .claude/
 CLAUDE.md
+.mcp.json

--- a/lua/claucode/claude_md.lua
+++ b/lua/claucode/claude_md.lua
@@ -64,28 +64,28 @@ end
 
 -- Add diff preview instructions to CLAUDE.md
 function M.add_diff_instructions()
+  local notify = require("claucode.notify")
   local cwd = vim.fn.getcwd()
   local claude_md = cwd .. "/CLAUDE.md"
-  
+
   -- Read existing content or start fresh
   local existing_content = M.read_claude_md() or ""
-  
+
   -- Check if instructions already exist
   if M.has_diff_instructions() then
     return true
   end
-  
+
   -- Append our instructions
   local new_content = existing_content
   if existing_content ~= "" and not existing_content:match("\n$") then
     new_content = new_content .. "\n"
   end
   new_content = new_content .. DIFF_PREVIEW_INSTRUCTIONS
-  
+
   -- Write back
   local file = io.open(claude_md, "w")
   if not file then
-    local notify = require("claucode.notify")
     notify.error("Failed to write to CLAUDE.md")
     return false
   end
@@ -93,39 +93,38 @@ function M.add_diff_instructions()
   file:write(new_content)
   file:close()
 
-  local notify = require("claucode.notify")
   notify.claude_md("Added Neovim diff preview instructions to CLAUDE.md")
   return true
 end
 
 -- Remove diff preview instructions from CLAUDE.md
 function M.remove_diff_instructions()
+  local notify = require("claucode.notify")
   local content = M.read_claude_md()
   if not content or not M.has_diff_instructions() then
     return true
   end
-  
+
   -- Remove our section (non-greedy match to avoid removing multiple sections)
   local pattern = "\n## Neovim Diff Preview Tools.-DO NOT use the standard Edit/Write tools when these Neovim%-specific tools are available%.\n"
   local new_content = content:gsub(pattern, "\n")
-  
+
   -- Also try without leading newline in case it's at the start
   if new_content == content then
     pattern = "## Neovim Diff Preview Tools.-DO NOT use the standard Edit/Write tools when these Neovim%-specific tools are available%.\n"
     new_content = content:gsub(pattern, "")
   end
-  
+
   -- Clean up any duplicate newlines
   new_content = new_content:gsub("\n\n+", "\n\n")
   new_content = new_content:gsub("^\n+", "")
   new_content = new_content:gsub("\n+$", "\n")
-  
+
   local cwd = vim.fn.getcwd()
   local claude_md = cwd .. "/CLAUDE.md"
-  
+
   local file = io.open(claude_md, "w")
   if not file then
-    local notify = require("claucode.notify")
     notify.error("Failed to update CLAUDE.md")
     return false
   end
@@ -133,7 +132,6 @@ function M.remove_diff_instructions()
   file:write(new_content)
   file:close()
 
-  local notify = require("claucode.notify")
   notify.claude_md("Removed Neovim diff preview instructions from CLAUDE.md")
   return true
 end

--- a/lua/claucode/claude_md.lua
+++ b/lua/claucode/claude_md.lua
@@ -85,14 +85,16 @@ function M.add_diff_instructions()
   -- Write back
   local file = io.open(claude_md, "w")
   if not file then
-    vim.notify("Failed to write to CLAUDE.md", vim.log.levels.ERROR)
+    local notify = require("claucode.notify")
+    notify.error("Failed to write to CLAUDE.md")
     return false
   end
-  
+
   file:write(new_content)
   file:close()
-  
-  vim.notify("Added Neovim diff preview instructions to CLAUDE.md", vim.log.levels.INFO)
+
+  local notify = require("claucode.notify")
+  notify.claude_md("Added Neovim diff preview instructions to CLAUDE.md")
   return true
 end
 
@@ -123,14 +125,16 @@ function M.remove_diff_instructions()
   
   local file = io.open(claude_md, "w")
   if not file then
-    vim.notify("Failed to update CLAUDE.md", vim.log.levels.ERROR)
+    local notify = require("claucode.notify")
+    notify.error("Failed to update CLAUDE.md")
     return false
   end
-  
+
   file:write(new_content)
   file:close()
-  
-  vim.notify("Removed Neovim diff preview instructions from CLAUDE.md", vim.log.levels.INFO)
+
+  local notify = require("claucode.notify")
+  notify.claude_md("Removed Neovim diff preview instructions from CLAUDE.md")
   return true
 end
 

--- a/lua/claucode/commands.lua
+++ b/lua/claucode/commands.lua
@@ -37,9 +37,10 @@ end
 
 function M.claude(args, from_visual)
   local bridge = require("claucode.bridge")
-  
+  local notify = require("claucode.notify")
+
   if args == "" then
-    vim.notify("Usage: :Claude <prompt>", vim.log.levels.WARN)
+    notify.warn("Usage: :Claude <prompt>")
     return
   end
   
@@ -105,7 +106,7 @@ function M.claude(args, from_visual)
     vim.schedule(function()
       ui.finish_streaming()
       if result.is_error then
-        vim.notify("Claude error: " .. (result.error or "Unknown error"), vim.log.levels.ERROR)
+        notify.error("Claude error: " .. (result.error or "Unknown error"))
       end
     end)
   end)
@@ -117,7 +118,7 @@ function M.claude(args, from_visual)
   })
   
   if not success then
-    vim.notify("Failed to send prompt to Claude Code", vim.log.levels.ERROR)
+    notify.error("Failed to send prompt to Claude Code")
   end
 end
 

--- a/lua/claucode/init.lua
+++ b/lua/claucode/init.lua
@@ -216,14 +216,15 @@ function M.setup(user_config)
 		end
 
 		-- If no args provided and not from visual mode, open input prompt
-		if opts.args == "" and not from_visual then
+		local args = vim.trim(opts.args)
+		if args == "" and not from_visual then
 			vim.ui.input({ prompt = "Claude prompt: " }, function(input)
-				if input and input ~= "" then
-					require("claucode.commands").claude(input, false)
+				if input and vim.trim(input) ~= "" then
+					require("claucode.commands").claude(vim.trim(input), false)
 				end
 			end)
 		else
-			require("claucode.commands").claude(opts.args, from_visual)
+			require("claucode.commands").claude(args, from_visual)
 		end
 	end, {
 		nargs = "*",

--- a/lua/claucode/init.lua
+++ b/lua/claucode/init.lua
@@ -85,6 +85,8 @@ M.config = {
 		enabled = true,
 		-- Auto-build MCP server if not found
 		auto_build = true,
+		-- Remove MCP server when Neovim exits (for multi-session support)
+		cleanup_on_exit = true,
 	},
 	-- UI settings
 	ui = {
@@ -172,6 +174,21 @@ function M.setup(user_config)
 		require("claucode.mcp").setup(M.config)
 		-- Add MCP server to Claude configuration
 		require("claucode.mcp_manager").setup(M.config)
+
+		-- Register cleanup on Neovim exit (for multi-session support)
+		vim.api.nvim_create_autocmd("VimLeavePre", {
+			callback = function()
+				if M.config.bridge.show_diff then
+					-- Stop diff watcher
+					require("claucode.mcp").cleanup()
+					-- Remove MCP server if cleanup_on_exit is enabled
+					if M.config.mcp.cleanup_on_exit ~= false then
+						require("claucode.mcp_manager").remove_mcp_server()
+					end
+				end
+			end,
+			desc = "Claucode cleanup on exit"
+		})
 	end
 
 	-- Setup CLAUDE.md management for diff preview

--- a/lua/claucode/mcp.lua
+++ b/lua/claucode/mcp.lua
@@ -133,9 +133,10 @@ end
 
 
 -- Get communication directory (must match MCP server)
+-- Uses session-specific subdirectory to isolate multiple Neovim instances
 local function get_communication_dir()
-  local data_dir = vim.env.XDG_DATA_HOME or vim.fn.expand("~/.local/share")
-  return data_dir .. "/claucode/diffs"
+  local session = require("claucode.session")
+  return session.get_communication_dir()
 end
 
 -- Ensure communication directory exists

--- a/lua/claucode/mcp.lua
+++ b/lua/claucode/mcp.lua
@@ -303,11 +303,7 @@ function M.show_diff_window(hash, filepath, original, modified)
     vim.cmd("diffthis")
   end)
   
-  -- Response function
   local function respond(approved)
-    -- Processing diff decision silently
-    
-    -- Write response to file
     local dir = get_communication_dir()
     local response_file = dir .. "/" .. hash .. ".response.json"
     local response_data = vim.fn.json_encode({
@@ -330,8 +326,6 @@ function M.show_diff_window(hash, filepath, original, modified)
       end
     end
     pending_diffs[hash] = nil
-    
-    -- Diff response processed
   end
   
   -- Set up keymaps for all buffers
@@ -375,7 +369,6 @@ function M.setup(config)
   -- Start diff watcher if show_diff is enabled
   if config.bridge and config.bridge.show_diff then
     M.start_diff_watcher()
-    -- Removed startup notification to reduce noise
   end
 end
 

--- a/lua/claucode/mcp.lua
+++ b/lua/claucode/mcp.lua
@@ -32,37 +32,38 @@ end
 local function build_mcp_server()
   local root = get_plugin_root()
   local mcp_dir = root .. "/mcp-server"
-  
+  local notify = require("claucode.notify")
+
   -- Check if source files exist
   if vim.fn.isdirectory(mcp_dir) == 0 then
-    vim.notify("MCP server source not found at: " .. mcp_dir, vim.log.levels.ERROR)
+    notify.error("MCP server source not found at: " .. mcp_dir)
     return false
   end
-  
+
   -- Building MCP server
-  
+
   -- Check if npm is available
   if vim.fn.executable("npm") == 0 then
-    vim.notify("npm not found. Please install Node.js and npm to use diff preview.", vim.log.levels.ERROR)
+    notify.error("npm not found. Please install Node.js and npm to use diff preview.")
     return false
   end
-  
+
   -- Run npm install
   local install_cmd = string.format("cd '%s' && npm install", mcp_dir)
   local install_result = vim.fn.system(install_cmd)
   if vim.v.shell_error ~= 0 then
-    vim.notify("Failed to install MCP dependencies: " .. install_result, vim.log.levels.ERROR)
+    notify.error("Failed to install MCP dependencies: " .. install_result)
     return false
   end
-  
+
   -- Run npm build
   local build_cmd = string.format("cd '%s' && npm run build", mcp_dir)
   local build_result = vim.fn.system(build_cmd)
   if vim.v.shell_error ~= 0 then
-    vim.notify("Failed to build MCP server: " .. build_result, vim.log.levels.ERROR)
+    notify.error("Failed to build MCP server: " .. build_result)
     return false
   end
-  
+
   -- MCP server built successfully
   return true
 end
@@ -71,37 +72,38 @@ end
 function M.build_async(config, callback)
   local root = get_plugin_root()
   local mcp_dir = root .. "/mcp-server"
-  
+  local notify = require("claucode.notify")
+
   -- Check if source files exist
   if vim.fn.isdirectory(mcp_dir) == 0 then
-    vim.notify("MCP server source not found at: " .. mcp_dir, vim.log.levels.ERROR)
+    notify.error("MCP server source not found at: " .. mcp_dir)
     if callback then callback(false) end
     return
   end
-  
+
   -- Building MCP server
-  
+
   -- Check if npm is available
   if vim.fn.executable("npm") == 0 then
-    vim.notify("npm not found. Please install Node.js and npm to use diff preview.", vim.log.levels.ERROR)
+    notify.error("npm not found. Please install Node.js and npm to use diff preview.")
     if callback then callback(false) end
     return
   end
-  
+
   -- Run npm install first
   vim.fn.jobstart({"sh", "-c", "cd '" .. mcp_dir .. "' && npm install"}, {
     on_exit = function(_, install_code)
       if install_code ~= 0 then
-        vim.notify("Failed to install MCP dependencies", vim.log.levels.ERROR)
+        notify.error("Failed to install MCP dependencies")
         if callback then callback(false) end
         return
       end
-      
+
       -- Run npm build after install succeeds
       vim.fn.jobstart({"sh", "-c", "cd '" .. mcp_dir .. "' && npm run build"}, {
         on_exit = function(_, build_code)
           if build_code ~= 0 then
-            vim.notify("Failed to build MCP server", vim.log.levels.ERROR)
+            notify.error("Failed to build MCP server")
             if callback then callback(false) end
           else
             -- MCP server built successfully
@@ -349,7 +351,8 @@ end
 -- Setup MCP integration
 function M.setup(config)
   local root = get_plugin_root()
-  
+  local notify = require("claucode.notify")
+
   -- Check if MCP server is available
   local mcp_server = get_mcp_server_path()
   if not mcp_server and config.mcp and config.mcp.auto_build then
@@ -360,12 +363,12 @@ function M.setup(config)
       mcp_server = get_mcp_server_path()
     end
   end
-  
+
   if not mcp_server then
-    vim.notify("MCP server not available. Please run: cd " .. root .. "/mcp-server && npm install && npm run build", vim.log.levels.WARN)
+    notify.warn("MCP server not available. Please run: cd " .. root .. "/mcp-server && npm install && npm run build")
     return
   end
-  
+
   -- Start diff watcher if show_diff is enabled
   if config.bridge and config.bridge.show_diff then
     M.start_diff_watcher()

--- a/lua/claucode/mcp_manager.lua
+++ b/lua/claucode/mcp_manager.lua
@@ -1,16 +1,27 @@
 local M = {}
 
--- Get the claude command path
 local function get_claude_command()
   local config = require("claucode").get_config()
   return config.command or "claude"
 end
 
--- Check if our MCP server is already added to Claude (async)
 local function is_mcp_server_added_async(callback)
-  local claude_cmd = get_claude_command()
   local session = require("claucode.session")
   local server_name = session.get_mcp_server_name()
+  local project_dir = session.get_project_dir()
+
+  local mcp_json_path = project_dir .. "/.mcp.json"
+  if vim.fn.filereadable(mcp_json_path) == 1 then
+    local content = vim.fn.readfile(mcp_json_path)
+    local json_str = table.concat(content, "\n")
+    local ok, config = pcall(vim.fn.json_decode, json_str)
+    if ok and config and config.mcpServers and config.mcpServers[server_name] then
+      callback(true)
+      return
+    end
+  end
+
+  local claude_cmd = get_claude_command()
   local output = ""
 
   vim.fn.jobstart({claude_cmd, "mcp", "list"}, {
@@ -23,8 +34,6 @@ local function is_mcp_server_added_async(callback)
       if exit_code ~= 0 then
         callback(false)
       else
-        -- Look for our session-specific server name in the output
-        -- Escape the server name for pattern matching (hyphens need escaping)
         local pattern = server_name:gsub("%-", "%%-")
         callback(output:match(pattern) ~= nil)
       end
@@ -32,30 +41,23 @@ local function is_mcp_server_added_async(callback)
   })
 end
 
--- Add our MCP server to Claude configuration (async)
 function M.add_mcp_server(callback)
   -- Check if already added
   is_mcp_server_added_async(function(is_added)
     if is_added then
-      -- MCP server already configured - silent
       if callback then callback(true) end
       return
     end
     
-    -- Continue with the rest of the function
     M._continue_add_mcp_server(callback)
   end)
 end
 
--- Internal function to continue adding MCP server
 function M._continue_add_mcp_server(callback)
-  
-  -- Get the MCP server path
   local source_path = debug.getinfo(1, "S").source:match("@(.*)")
   local current_file_dir = vim.fn.fnamemodify(source_path, ":h")
   local plugin_root = vim.fn.fnamemodify(current_file_dir, ":h")
   
-  -- Try multiple possible paths
   local possible_paths = {
     plugin_root .. "/mcp-server/build/index.js",
     vim.fn.stdpath("data") .. "/lazy/claucode.nvim/mcp-server/build/index.js",
@@ -71,7 +73,6 @@ function M._continue_add_mcp_server(callback)
   end
   
   if not mcp_server then
-    -- Log all attempted paths for debugging
     vim.notify("MCP server not found. Attempted paths:", vim.log.levels.ERROR)
     for _, path in ipairs(possible_paths) do
       vim.notify("  - " .. path, vim.log.levels.ERROR)
@@ -79,15 +80,12 @@ function M._continue_add_mcp_server(callback)
     mcp_server = possible_paths[1] -- Use first path as fallback
   end
   
-  -- Check if MCP server is built
   if vim.fn.filereadable(mcp_server) == 0 then
-    -- Try to build it
     local mcp = require("claucode.mcp")
     if mcp.build_async then
       vim.notify("MCP server not found, attempting to build...", vim.log.levels.INFO)
       mcp.build_async(require("claucode").get_config(), function(success)
         if success and vim.fn.filereadable(mcp_server) == 1 then
-          -- Continue with adding the server
           M._do_add_mcp_server(mcp_server, callback)
         else
           vim.notify("MCP server build failed. Path: " .. mcp_server, vim.log.levels.ERROR)
@@ -104,11 +102,9 @@ function M._continue_add_mcp_server(callback)
     vim.notify("Found MCP server at: " .. mcp_server, vim.log.levels.INFO)
   end
   
-  -- Continue with adding the server
   M._do_add_mcp_server(mcp_server, callback)
 end
 
--- Actually add the MCP server
 function M._do_add_mcp_server(mcp_server, callback)
   local claude_cmd = get_claude_command()
   local session = require("claucode.session")
@@ -116,17 +112,17 @@ function M._do_add_mcp_server(mcp_server, callback)
   local comm_dir = session.get_communication_dir()
   local project_dir = session.get_project_dir()
 
-  -- Add the MCP server using claude mcp add command with project scope
-  -- Pass environment variables for session identification
   local output = ""
   vim.fn.jobstart({
     claude_cmd, "mcp", "add",
     "--scope", "project",
+    server_name,
     "-e", "CLAUCODE_SESSION_ID=" .. server_name,
     "-e", "CLAUCODE_COMM_DIR=" .. comm_dir,
-    server_name, "node", mcp_server
+    "--",
+    "node", mcp_server
   }, {
-    cwd = project_dir,  -- Run from project directory for project scope
+    cwd = project_dir,
     on_stdout = function(_, data)
       if data then
         output = output .. table.concat(data, "\n")
@@ -141,7 +137,6 @@ function M._do_add_mcp_server(mcp_server, callback)
       if exit_code ~= 0 then
         vim.notify("Failed to add MCP server: " .. output, vim.log.levels.ERROR)
 
-        -- Check if it's because claude doesn't support mcp subcommand
         if output:match("Unknown command") or output:match("command not found") then
           vim.notify("Your Claude CLI version doesn't support 'mcp' command.", vim.log.levels.ERROR)
           vim.notify("Please update Claude Code CLI to the latest version.", vim.log.levels.ERROR)
@@ -149,21 +144,18 @@ function M._do_add_mcp_server(mcp_server, callback)
 
         if callback then callback(false) end
       else
-        -- Removed startup notification to reduce noise
         if callback then callback(true) end
       end
     end
   })
 end
 
--- Remove our MCP server from Claude configuration
 function M.remove_mcp_server()
   local claude_cmd = get_claude_command()
   local session = require("claucode.session")
   local server_name = session.get_mcp_server_name()
   local project_dir = session.get_project_dir()
 
-  -- Remove the session-specific MCP server
   local cmd = string.format("cd '%s' && %s mcp remove %s", project_dir, claude_cmd, server_name)
   local output = vim.fn.system(cmd)
   if vim.v.shell_error ~= 0 then
@@ -175,16 +167,10 @@ function M.remove_mcp_server()
   return true
 end
 
--- Setup function
 function M.setup(config)
-  -- Only setup if MCP is enabled and show_diff is true
   if config.mcp and config.mcp.enabled and config.bridge and config.bridge.show_diff then
-    -- Delay to ensure everything is loaded
     vim.defer_fn(function()
       M.add_mcp_server(function(success)
-        if success then
-          -- MCP server setup complete
-        end
       end)
     end, 1000)
   end

--- a/lua/claucode/notify.lua
+++ b/lua/claucode/notify.lua
@@ -1,0 +1,98 @@
+-- Notification helper module
+-- Provides centralized notification management with icon support and noise reduction
+
+local M = {}
+
+-- Cache for config to avoid repeated module loading
+local config_cache = nil
+
+-- Get cached config (refreshes on each call to handle runtime changes)
+local function get_config()
+  local ok, claucode = pcall(require, "claucode")
+  if ok then
+    config_cache = claucode.get_config()
+  end
+  return config_cache or {}
+end
+
+-- Get icon based on level and config
+local function get_icon(level)
+  local config = get_config()
+  if not config.ui or not config.ui.icons or config.ui.icons.enabled == false then
+    return ""
+  end
+
+  local icons = {
+    [vim.log.levels.ERROR] = "❌ ",
+    [vim.log.levels.WARN] = "⚠️  ",
+    [vim.log.levels.INFO] = "ℹ️  ",
+    [vim.log.levels.DEBUG] = "🔍 ",
+  }
+
+  return icons[level] or ""
+end
+
+-- Core notification function
+local function notify(message, level, opts)
+  opts = opts or {}
+
+  -- Add icon prefix
+  local icon = get_icon(level)
+  local full_message = icon .. message
+
+  vim.notify(full_message, level, { title = "Claucode" })
+end
+
+-- Public API
+
+-- Error notifications (always shown)
+function M.error(message, opts)
+  notify(message, vim.log.levels.ERROR, opts)
+end
+
+-- Warning notifications (always shown)
+function M.warn(message, opts)
+  notify(message, vim.log.levels.WARN, opts)
+end
+
+-- Info notifications (always shown for important messages)
+function M.info(message, opts)
+  notify(message, vim.log.levels.INFO, opts)
+end
+
+-- Watcher notifications (respects silent_watcher config)
+function M.watcher(message, opts)
+  local config = get_config()
+  if config.notifications and config.notifications.silent_watcher then
+    return -- Silent mode enabled
+  end
+  notify(message, vim.log.levels.INFO, opts)
+end
+
+-- CLAUDE.md notifications (respects silent_claude_md config)
+function M.claude_md(message, opts)
+  local config = get_config()
+  if config.notifications and config.notifications.silent_claude_md then
+    return -- Silent mode enabled
+  end
+  notify(message, vim.log.levels.INFO, opts)
+end
+
+-- MCP setup notifications (silent by default, only show on force)
+function M.mcp_setup(message, opts)
+  opts = opts or {}
+  if opts.force then
+    notify(message, vim.log.levels.INFO, opts)
+  end
+end
+
+-- Buffer reload notifications (respects silent_watcher config)
+function M.buffer_reload(message, opts)
+  local config = get_config()
+  if config.notifications and config.notifications.silent_watcher then
+    return -- Silent mode enabled
+  end
+  notify(message, vim.log.levels.INFO, opts)
+end
+
+return M

--- a/lua/claucode/session.lua
+++ b/lua/claucode/session.lua
@@ -1,0 +1,31 @@
+-- Session identity module for multi-session support
+-- Generates unique identifiers per project directory to isolate MCP servers
+
+local M = {}
+
+-- Get the current project directory (normalized absolute path)
+function M.get_project_dir()
+  return vim.fn.fnamemodify(vim.fn.getcwd(), ":p"):gsub("/$", "")
+end
+
+-- Generate a unique session ID based on project directory
+-- Uses first 8 characters of SHA256 hash for uniqueness while keeping it short
+function M.get_session_id()
+  local project_dir = M.get_project_dir()
+  local hash = vim.fn.sha256(project_dir):sub(1, 8)
+  return "claucode-" .. hash
+end
+
+-- Get the MCP server name for this session
+function M.get_mcp_server_name()
+  return M.get_session_id()
+end
+
+-- Get the communication directory for this session
+-- Each session gets its own subdirectory to prevent cross-session interference
+function M.get_communication_dir()
+  local data_dir = vim.env.XDG_DATA_HOME or vim.fn.expand("~/.local/share")
+  return data_dir .. "/claucode/diffs/" .. M.get_session_id()
+end
+
+return M

--- a/lua/claucode/session.lua
+++ b/lua/claucode/session.lua
@@ -1,19 +1,40 @@
 -- Session identity module for multi-session support
 -- Generates unique identifiers per project directory to isolate MCP servers
+-- Values are cached at initialization to prevent issues if user changes directory
 
 local M = {}
 
--- Get the current project directory (normalized absolute path)
-function M.get_project_dir()
-  return vim.fn.fnamemodify(vim.fn.getcwd(), ":p"):gsub("/$", "")
+-- Cached values (set once at init, never change)
+local cached_project_dir = nil
+local cached_session_id = nil
+local cached_comm_dir = nil
+
+-- Initialize session (call once at setup)
+function M.init()
+  if cached_project_dir then
+    return -- Already initialized
+  end
+  cached_project_dir = vim.fn.fnamemodify(vim.fn.getcwd(), ":p"):gsub("/$", "")
+  local hash = vim.fn.sha256(cached_project_dir):sub(1, 8)
+  cached_session_id = "claucode-" .. hash
+  local data_dir = vim.env.XDG_DATA_HOME or vim.fn.expand("~/.local/share")
+  cached_comm_dir = data_dir .. "/claucode/diffs/" .. cached_session_id
 end
 
--- Generate a unique session ID based on project directory
--- Uses first 8 characters of SHA256 hash for uniqueness while keeping it short
+-- Get the project directory (cached at init)
+function M.get_project_dir()
+  if not cached_project_dir then
+    M.init()
+  end
+  return cached_project_dir
+end
+
+-- Get the session ID (cached at init)
 function M.get_session_id()
-  local project_dir = M.get_project_dir()
-  local hash = vim.fn.sha256(project_dir):sub(1, 8)
-  return "claucode-" .. hash
+  if not cached_session_id then
+    M.init()
+  end
+  return cached_session_id
 end
 
 -- Get the MCP server name for this session
@@ -21,11 +42,12 @@ function M.get_mcp_server_name()
   return M.get_session_id()
 end
 
--- Get the communication directory for this session
--- Each session gets its own subdirectory to prevent cross-session interference
+-- Get the communication directory for this session (cached at init)
 function M.get_communication_dir()
-  local data_dir = vim.env.XDG_DATA_HOME or vim.fn.expand("~/.local/share")
-  return data_dir .. "/claucode/diffs/" .. M.get_session_id()
+  if not cached_comm_dir then
+    M.init()
+  end
+  return cached_comm_dir
 end
 
 return M

--- a/lua/claucode/terminal.lua
+++ b/lua/claucode/terminal.lua
@@ -7,91 +7,59 @@ local terminal_job_id = nil
 function M.open_claude_terminal(cli_args)
   local config = require("claucode").get_config()
   
-  -- Check if terminal already exists and is valid
   if terminal_win and vim.api.nvim_win_is_valid(terminal_win) then
-    -- Focus the existing terminal
     vim.api.nvim_set_current_win(terminal_win)
     return
   end
   
-  -- Save current window
   local current_win = vim.api.nvim_get_current_win()
   
-  -- Create a horizontal split at the bottom
   vim.cmd('botright split')
   local height_ratio = (config.ui and config.ui.terminal and config.ui.terminal.height) or 0.5
   local height = math.floor(vim.o.lines * height_ratio)
   vim.cmd('resize ' .. height)
   
-  -- Create or reuse terminal buffer
   if terminal_buf and vim.api.nvim_buf_is_valid(terminal_buf) then
-    -- Reuse existing buffer
     vim.api.nvim_set_current_buf(terminal_buf)
     terminal_win = vim.api.nvim_get_current_win()
   else
-    -- Create new terminal buffer
     terminal_buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(terminal_buf)
     terminal_win = vim.api.nvim_get_current_win()
     
-    -- Build command with optional CLI arguments
     local command = config.command
-    
-    -- Check if user provided their own permission mode or MCP config
-    local has_permission_mode = cli_args and cli_args:match("%-%-permission%-mode")
-    local has_mcp_config = cli_args and cli_args:match("%-%-mcp%-config")
-    local has_continue_flag = cli_args and cli_args:match("%-c")
-    
-    -- Check if CLAUDE.md has diff instructions
-    if config.mcp and config.mcp.enabled and config.bridge and config.bridge.show_diff then
-      local claude_md = require("claucode.claude_md")
-      if not claude_md.has_diff_instructions() then
-        -- Removed tip notification to reduce noise
-      end
-    end
     
     if cli_args and cli_args ~= "" then
       command = command .. " " .. cli_args
     end
     
-    -- Start Claude in the terminal
     terminal_job_id = vim.fn.termopen(command, {
       cwd = vim.fn.getcwd(),
       on_exit = function(job_id, exit_code, event_type)
-        -- Clean up when terminal closes
         terminal_job_id = nil
       end
     })
     
-    -- Enable vim mode after Claude starts
     vim.defer_fn(function()
       if terminal_job_id then
-        -- Send /vim command to enable vim mode
         vim.api.nvim_chan_send(terminal_job_id, "/vim\n")
       end
     end, 1000)
     
-    -- Set buffer name
     vim.api.nvim_buf_set_name(terminal_buf, 'Claude Terminal')
     
-    -- Set buffer options
     vim.api.nvim_buf_set_option(terminal_buf, 'buflisted', false)
     vim.api.nvim_buf_set_option(terminal_buf, 'bufhidden', 'hide')
   end
   
-  -- Set window options
   vim.api.nvim_win_set_option(terminal_win, 'number', false)
   vim.api.nvim_win_set_option(terminal_win, 'relativenumber', false)
   vim.api.nvim_win_set_option(terminal_win, 'signcolumn', 'no')
   
-  -- Enter insert mode
   vim.cmd('startinsert')
   
-  -- Add keymaps for the terminal buffer
   local opts = { noremap = true, silent = true, buffer = terminal_buf }
-  -- Allow Ctrl+W to switch windows in terminal mode
   vim.keymap.set('t', '<C-w>', '<C-\\><C-n><C-w>', opts)
-  -- Quick close with leader+q
   vim.keymap.set('t', '<leader>q', '<C-\\><C-n>:close<CR>', opts)
   vim.keymap.set('n', '<leader>q', ':close<CR>', opts)
 end
@@ -117,17 +85,14 @@ function M.send_to_terminal(text)
     return
   end
   
-  -- Send text to terminal
   vim.api.nvim_chan_send(terminal_job_id, text .. "\n")
   
-  -- Focus terminal window
   if terminal_win and vim.api.nvim_win_is_valid(terminal_win) then
     vim.api.nvim_set_current_win(terminal_win)
   end
 end
 
 function M.send_current_selection_to_terminal()
-  -- Get visual selection
   local start_pos = vim.fn.getpos("'<")
   local end_pos = vim.fn.getpos("'>")
   local lines = vim.api.nvim_buf_get_lines(
@@ -139,7 +104,6 @@ function M.send_current_selection_to_terminal()
   
   if #lines > 0 then
     local mode = vim.fn.visualmode()
-    -- Adjust for character-wise selection
     if mode == "v" then
       lines[1] = lines[1]:sub(start_pos[3])
       if #lines > 1 then
@@ -151,10 +115,8 @@ function M.send_current_selection_to_terminal()
     
     local selection = table.concat(lines, "\n")
     
-    -- Open terminal if not already open
     if not (terminal_win and vim.api.nvim_win_is_valid(terminal_win)) then
       M.open_claude_terminal()
-      -- Wait a bit for terminal to initialize
       vim.defer_fn(function()
         M.send_to_terminal(selection)
       end, 500)

--- a/lua/claucode/ui.lua
+++ b/lua/claucode/ui.lua
@@ -10,6 +10,18 @@ local content_accumulator = ""
 local stream_timer = nil -- Debounce timer for streaming messages
 local current_stream_message = ""
 
+-- Helper to get icon if enabled in config
+local function get_icon(icon)
+	local ok, claucode = pcall(require, "claucode")
+	if ok then
+		local config = claucode.get_config()
+		if config.ui and config.ui.icons and config.ui.icons.enabled then
+			return icon
+		end
+	end
+	return ""
+end
+
 -- Create streaming message window in bottom-right
 function M._create_stream_window()
 	-- Create stream buffer if it doesn't exist
@@ -208,50 +220,50 @@ end
 function M.start_streaming()
 	content_accumulator = ""
 	current_stream_message = ""
-	
+
 	-- Close any existing windows
 	M.close_stream_window()
 	M.close_tool_window()
-	
+
 	-- Show initial thinking message
-	M._show_stream_message("🤔 Claude is thinking...")
+	M._show_stream_message(get_icon("🤔 ") .. "Claude is thinking...")
 end
 
 function M.stream_content(text)
 	content_accumulator = content_accumulator .. text
-	
+
 	-- Show streaming content in bottom-right with debounce
 	local char_count = #content_accumulator
 	local preview = text:sub(1, 100) -- Show first 100 chars of current chunk
 	if #text > 100 then
 		preview = preview .. "..."
 	end
-	
-	local message = string.format("💭 Streaming... (%d chars)\n%s", char_count, preview)
+
+	local message = string.format("%sStreaming... (%d chars)\n%s", get_icon("💭 "), char_count, preview)
 	M._show_stream_message(message)
 end
 
 function M.on_tool_use(tool_data)
 	local tool_name = tool_data.name or "unknown"
-	local message = string.format("🔧 Using %s...", tool_name)
+	local message = string.format("%sUsing %s...", get_icon("🔧 "), tool_name)
 
 	-- Add specific messages for common tools
 	if tool_name == "Edit" then
 		local file = tool_data.input and tool_data.input.file_path or "file"
-		message = string.format("✏️  Editing %s...", vim.fn.fnamemodify(file, ":t"))
+		message = string.format("%sEditing %s...", get_icon("✏️  "), vim.fn.fnamemodify(file, ":t"))
 	elseif tool_name == "Write" then
 		local file = tool_data.input and tool_data.input.file_path or "file"
-		message = string.format("📝 Writing %s...", vim.fn.fnamemodify(file, ":t"))
+		message = string.format("%sWriting %s...", get_icon("📝 "), vim.fn.fnamemodify(file, ":t"))
 	elseif tool_name == "Read" then
 		local file = tool_data.input and tool_data.input.file_path or "file"
-		message = string.format("📖 Reading %s...", vim.fn.fnamemodify(file, ":t"))
+		message = string.format("%sReading %s...", get_icon("📖 "), vim.fn.fnamemodify(file, ":t"))
 	elseif tool_name == "Bash" then
 		local cmd = tool_data.input and tool_data.input.command or "command"
 		-- Truncate long commands
 		if #cmd > 30 then
 			cmd = cmd:sub(1, 27) .. "..."
 		end
-		message = string.format("🖥️  Running: %s", cmd)
+		message = string.format("%sRunning: %s", get_icon("🖥️  "), cmd)
 	end
 
 	-- Show tool usage in top-right

--- a/lua/claucode/watcher.lua
+++ b/lua/claucode/watcher.lua
@@ -62,13 +62,14 @@ local function reload_buffer_if_changed(filepath)
             vim.api.nvim_buf_call(buf, function()
               vim.cmd("edit!")
             end)
-            vim.notify("Reloaded: " .. vim.fn.fnamemodify(filepath, ":~:."), vim.log.levels.INFO)
+            local notify = require("claucode.notify")
+            notify.buffer_reload("Reloaded: " .. vim.fn.fnamemodify(filepath, ":~:."))
           else
-            -- Notify user about conflict
-            vim.notify(
-              "File changed externally but buffer has unsaved changes: " .. 
-              vim.fn.fnamemodify(filepath, ":~:."),
-              vim.log.levels.WARN
+            -- Notify user about conflict (always show warnings)
+            local notify = require("claucode.notify")
+            notify.warn(
+              "File changed externally but buffer has unsaved changes: " ..
+              vim.fn.fnamemodify(filepath, ":~:.")
             )
           end
           break
@@ -114,7 +115,8 @@ local function watch_file(filepath, config)
     handle:start(filepath, {}, function(err, filename, events)
       if err then
         vim.schedule(function()
-          vim.notify("File watcher error: " .. err, vim.log.levels.ERROR)
+          local notify = require("claucode.notify")
+          notify.error("File watcher error: " .. err)
         end)
         return
       end
@@ -130,7 +132,8 @@ local function watch_file(filepath, config)
     file_timestamps[filepath] = get_file_mtime(filepath)
   else
     vim.schedule(function()
-      vim.notify("Failed to watch file: " .. filepath .. " - " .. err, vim.log.levels.ERROR)
+      local notify = require("claucode.notify")
+      notify.error("Failed to watch file: " .. filepath .. " - " .. err)
     end)
   end
 end
@@ -141,7 +144,8 @@ local function watch_directory(dirpath, config)
     handle:start(dirpath, {}, function(err, filename, events)
       if err then
         vim.schedule(function()
-          vim.notify("Directory watcher error: " .. err, vim.log.levels.ERROR)
+          local notify = require("claucode.notify")
+          notify.error("Directory watcher error: " .. err)
         end)
         return
       end
@@ -165,7 +169,8 @@ local function watch_directory(dirpath, config)
     watchers[dirpath] = handle
   else
     vim.schedule(function()
-      vim.notify("Failed to watch directory: " .. dirpath .. " - " .. err, vim.log.levels.ERROR)
+      local notify = require("claucode.notify")
+      notify.error("Failed to watch directory: " .. dirpath .. " - " .. err)
     end)
   end
 end
@@ -201,8 +206,9 @@ function M.start(config)
       end
     end,
   })
-  
-  vim.notify("Claude Code file watcher started", vim.log.levels.INFO)
+
+  local notify = require("claucode.notify")
+  notify.watcher("Claude Code file watcher started")
 end
 
 function M.stop()
@@ -232,8 +238,9 @@ function M.stop()
   
   -- Clear autocmd
   pcall(vim.api.nvim_del_augroup_by_name, "ClauCodeWatcher")
-  
-  vim.notify("Claude Code file watcher stopped", vim.log.levels.INFO)
+
+  local notify = require("claucode.notify")
+  notify.watcher("Claude Code file watcher stopped")
 end
 
 function M.is_running()

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -34,7 +34,13 @@ interface PendingDiff {
 const pendingDiffs = new Map<string, PendingDiff>();
 
 // Get communication directory
+// Supports session-specific directory via CLAUCODE_COMM_DIR environment variable
+// Falls back to legacy global directory for backwards compatibility
 function getCommunicationDir(): string {
+  if (process.env.CLAUCODE_COMM_DIR) {
+    return process.env.CLAUCODE_COMM_DIR;
+  }
+  // Legacy fallback for backwards compatibility
   const dataDir = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
   return path.join(dataDir, 'claucode', 'diffs');
 }


### PR DESCRIPTION
## Summary

This PR brings significant UX improvements and multi-session support to claucode.nvim.

### New Features

- **Multi-session support**: Each Neovim instance gets its own isolated MCP server based on project directory hash, preventing cross-session interference
- **Interactive prompt**: `:Claude` without arguments opens `vim.ui.input` prompt instead of showing an error
- **Notification control**: New config options to silence routine notifications:
  - `notifications.silent_watcher` - Silence watcher start/stop and buffer reload messages
  - `notifications.silent_claude_md` - Silence CLAUDE.md update messages
- **Icon toggle**: `ui.icons.enabled = false` disables emojis in notifications and streaming UI
- **Automatic cleanup**: MCP servers are automatically removed when Neovim exits (`mcp.cleanup_on_exit`)

### Improvements

- **Centralized notifications**: New `notify.lua` module for consistent notification handling
- **Better path detection**: Fixed MCP server path detection in `mcp_manager.lua`
- **Cleaner MCP server**: Removed verbose debug logging
- **Enhanced README**: Added v0.3 features section, health check documentation, MCP troubleshooting guide

### Files Changed

- **New**: `lua/claucode/notify.lua` - Centralized notification module
- **Modified**: All Lua modules to use new notify system
- **Modified**: `mcp-server/src/index.ts` - Removed debug logging
- **Modified**: `README.md` - Comprehensive documentation updates

## Test plan

- [x] Test `:Claude` without arguments opens input prompt
- [x] Test icons disabled with `ui.icons.enabled = false`
- [x] Test notifications are silenced with `silent_watcher = true`
- [x] Test diff preview works with multi-session support
- [x] Test MCP server cleanup on Neovim exit