### PR TITLE
Security Hardening and Code Quality Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ package-lock.json
 # IDE
 .vscode/
 .idea/
+.github/
 
 # Build artifacts
 *.rock

--- a/lua/claucode/bridge.lua
+++ b/lua/claucode/bridge.lua
@@ -6,12 +6,6 @@ local current_stdin = nil
 local output_buffer = ""
 local callbacks = {}
 
-local function escape_prompt(prompt)
-  -- Escape special characters for shell
-  return prompt:gsub('"', '\\"'):gsub('\n', '\\n')
-end
-
-
 local function parse_streaming_json(line)
   if line == "" then return end
   

--- a/lua/claucode/mcp_manager.lua
+++ b/lua/claucode/mcp_manager.lua
@@ -160,7 +160,14 @@ function M.remove_mcp_server()
   local project_dir = session.get_project_dir()
 
   -- Use array form to prevent shell injection
-  local output = vim.fn.system({claude_cmd, "mcp", "remove", server_name}, nil, project_dir)
+  -- vim.fn.system doesn't support cwd parameter, so we temporarily change directory
+  local output
+  do
+    local prev_cwd = vim.fn.getcwd()
+    vim.api.nvim_set_current_dir(project_dir)
+    output = vim.fn.system({claude_cmd, "mcp", "remove", server_name})
+    vim.api.nvim_set_current_dir(prev_cwd)
+  end
   if vim.v.shell_error ~= 0 then
     notify.error("Failed to remove MCP server: " .. (output or ""))
     return false

--- a/lua/claucode/mcp_manager.lua
+++ b/lua/claucode/mcp_manager.lua
@@ -159,10 +159,10 @@ function M.remove_mcp_server()
   local server_name = session.get_mcp_server_name()
   local project_dir = session.get_project_dir()
 
-  local cmd = string.format("cd '%s' && %s mcp remove %s", project_dir, claude_cmd, server_name)
-  local output = vim.fn.system(cmd)
+  -- Use array form to prevent shell injection
+  local output = vim.fn.system({claude_cmd, "mcp", "remove", server_name}, nil, project_dir)
   if vim.v.shell_error ~= 0 then
-    notify.error("Failed to remove MCP server: " .. output)
+    notify.error("Failed to remove MCP server: " .. (output or ""))
     return false
   end
 

--- a/lua/claucode/session.lua
+++ b/lua/claucode/session.lua
@@ -14,10 +14,15 @@ function M.init()
   if cached_project_dir then
     return -- Already initialized
   end
-  cached_project_dir = vim.fn.fnamemodify(vim.fn.getcwd(), ":p"):gsub("/$", "")
+  -- Normalize path: get absolute path and remove trailing slash/backslash
+  cached_project_dir = vim.fn.fnamemodify(vim.fn.getcwd(), ":p")
+  -- Remove trailing path separator (works on both Windows and Unix)
+  cached_project_dir = cached_project_dir:gsub("[/\\]$", "")
   local hash = vim.fn.sha256(cached_project_dir):sub(1, 8)
   cached_session_id = "claucode-" .. hash
+  -- Use vim.fn.expand for cross-platform path handling
   local data_dir = vim.env.XDG_DATA_HOME or vim.fn.expand("~/.local/share")
+  -- Use forward slashes for consistency (Lua/Neovim handles this on Windows)
   cached_comm_dir = data_dir .. "/claucode/diffs/" .. cached_session_id
 end
 

--- a/lua/claucode/terminal.lua
+++ b/lua/claucode/terminal.lua
@@ -27,13 +27,18 @@ function M.open_claude_terminal(cli_args)
     vim.api.nvim_set_current_buf(terminal_buf)
     terminal_win = vim.api.nvim_get_current_win()
     
-    local command = config.command
+    -- Build command as array to prevent injection
+    local cmd_args = {config.command}
     
+    -- Parse cli_args safely if provided
     if cli_args and cli_args ~= "" then
-      command = command .. " " .. cli_args
+      -- Split args by whitespace (simple tokenization)
+      for arg in cli_args:gmatch("%S+") do
+        table.insert(cmd_args, arg)
+      end
     end
     
-    terminal_job_id = vim.fn.termopen(command, {
+    terminal_job_id = vim.fn.termopen(cmd_args, {
       cwd = vim.fn.getcwd(),
       on_exit = function(job_id, exit_code, event_type)
         terminal_job_id = nil
@@ -48,13 +53,13 @@ function M.open_claude_terminal(cli_args)
     
     vim.api.nvim_buf_set_name(terminal_buf, 'Claude Terminal')
     
-    vim.api.nvim_buf_set_option(terminal_buf, 'buflisted', false)
-    vim.api.nvim_buf_set_option(terminal_buf, 'bufhidden', 'hide')
+    vim.bo[terminal_buf].buflisted = false
+    vim.bo[terminal_buf].bufhidden = 'hide'
   end
   
-  vim.api.nvim_win_set_option(terminal_win, 'number', false)
-  vim.api.nvim_win_set_option(terminal_win, 'relativenumber', false)
-  vim.api.nvim_win_set_option(terminal_win, 'signcolumn', 'no')
+  vim.wo[terminal_win].number = false
+  vim.wo[terminal_win].relativenumber = false
+  vim.wo[terminal_win].signcolumn = 'no'
   
   vim.cmd('startinsert')
   

--- a/lua/claucode/terminal.lua
+++ b/lua/claucode/terminal.lua
@@ -32,9 +32,41 @@ function M.open_claude_terminal(cli_args)
     
     -- Parse cli_args safely if provided
     if cli_args and cli_args ~= "" then
-      -- Split args by whitespace (simple tokenization)
-      for arg in cli_args:gmatch("%S+") do
-        table.insert(cmd_args, arg)
+      -- Robust tokenization that handles quoted strings
+      local i = 1
+      local len = #cli_args
+      while i <= len do
+        -- Skip whitespace
+        while i <= len and cli_args:sub(i, i):match("%s") do
+          i = i + 1
+        end
+        if i > len then break end
+        
+        local char = cli_args:sub(i, i)
+        local arg = ""
+        
+        if char == '"' or char == "'" then
+          -- Quoted argument: find matching closing quote
+          local quote = char
+          i = i + 1
+          local start = i
+          while i <= len and cli_args:sub(i, i) ~= quote do
+            i = i + 1
+          end
+          arg = cli_args:sub(start, i - 1)
+          i = i + 1 -- skip closing quote
+        else
+          -- Unquoted argument: read until whitespace
+          local start = i
+          while i <= len and not cli_args:sub(i, i):match("%s") do
+            i = i + 1
+          end
+          arg = cli_args:sub(start, i - 1)
+        end
+        
+        if arg ~= "" then
+          table.insert(cmd_args, arg)
+        end
       end
     end
     

--- a/lua/claucode/ui.lua
+++ b/lua/claucode/ui.lua
@@ -27,9 +27,9 @@ function M._create_stream_window()
 	-- Create stream buffer if it doesn't exist
 	if not stream_buf or not vim.api.nvim_buf_is_valid(stream_buf) then
 		stream_buf = vim.api.nvim_create_buf(false, true)
-		vim.api.nvim_buf_set_option(stream_buf, "buftype", "nofile")
-		vim.api.nvim_buf_set_option(stream_buf, "swapfile", false)
-		vim.api.nvim_buf_set_option(stream_buf, "filetype", "markdown")
+		vim.bo[stream_buf].buftype = "nofile"
+		vim.bo[stream_buf].swapfile = false
+		vim.bo[stream_buf].filetype = "markdown"
 	end
 
 	-- Calculate window dimensions - bottom right corner
@@ -56,8 +56,8 @@ function M._create_stream_window()
 		})
 
 		-- Set window options
-		vim.api.nvim_win_set_option(stream_win, "wrap", true)
-		vim.api.nvim_win_set_option(stream_win, "linebreak", true)
+		vim.wo[stream_win].wrap = true
+		vim.wo[stream_win].linebreak = true
 	end
 end
 
@@ -90,9 +90,9 @@ function M._create_tool_window()
 	-- Create tool buffer if it doesn't exist
 	if not tool_buf or not vim.api.nvim_buf_is_valid(tool_buf) then
 		tool_buf = vim.api.nvim_create_buf(false, true)
-		vim.api.nvim_buf_set_option(tool_buf, "buftype", "nofile")
-		vim.api.nvim_buf_set_option(tool_buf, "swapfile", false)
-		vim.api.nvim_buf_set_option(tool_buf, "filetype", "markdown")
+		vim.bo[tool_buf].buftype = "nofile"
+		vim.bo[tool_buf].swapfile = false
+		vim.bo[tool_buf].filetype = "markdown"
 	end
 
 	-- Calculate window dimensions - top right corner
@@ -119,8 +119,8 @@ function M._create_tool_window()
 		})
 
 		-- Set window options
-		vim.api.nvim_win_set_option(tool_win, "wrap", true)
-		vim.api.nvim_win_set_option(tool_win, "linebreak", true)
+		vim.wo[tool_win].wrap = true
+		vim.wo[tool_win].linebreak = true
 	end
 end
 
@@ -143,9 +143,9 @@ function M.show_response(content)
 	-- Create buffer if it doesn't exist
 	if not popup_buf or not vim.api.nvim_buf_is_valid(popup_buf) then
 		popup_buf = vim.api.nvim_create_buf(false, true)
-		vim.api.nvim_buf_set_option(popup_buf, "buftype", "nofile")
-		vim.api.nvim_buf_set_option(popup_buf, "swapfile", false)
-		vim.api.nvim_buf_set_option(popup_buf, "filetype", "markdown")
+		vim.bo[popup_buf].buftype = "nofile"
+		vim.bo[popup_buf].swapfile = false
+		vim.bo[popup_buf].filetype = "markdown"
 	end
 
 	-- Split content into lines
@@ -178,8 +178,8 @@ function M.show_response(content)
 	})
 
 	-- Set window options
-	vim.api.nvim_win_set_option(popup_win, "wrap", true)
-	vim.api.nvim_win_set_option(popup_win, "linebreak", true)
+	vim.wo[popup_win].wrap = true
+	vim.wo[popup_win].linebreak = true
 
 	-- Add keymaps for the popup
 	local opts = { noremap = true, silent = true, buffer = popup_buf }

--- a/lua/claucode/watcher.lua
+++ b/lua/claucode/watcher.lua
@@ -54,8 +54,8 @@ local function reload_buffer_if_changed(filepath)
       if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_is_loaded(buf) then
         local buf_name = vim.api.nvim_buf_get_name(buf)
         if buf_name == filepath then
-          -- Check if buffer has unsaved changes
-          local modified = vim.api.nvim_buf_get_option(buf, "modified")
+          -- Check if buffer has unsaved changes using modern vim.bo API
+          local modified = vim.bo[buf].modified
           
           if not modified then
             -- Reload the buffer

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -33,6 +33,33 @@ interface PendingDiff {
 
 const pendingDiffs = new Map<string, PendingDiff>();
 
+// Get the working directory (project root)
+// This is set by Neovim when spawning the MCP server
+function getWorkingDirectory(): string {
+  return process.cwd();
+}
+
+// Validate that a file path is within the project directory
+// Prevents path traversal attacks (e.g., ../../../etc/passwd)
+function validateFilePath(filePath: string): { valid: boolean; resolved: string; error?: string } {
+  const workDir = getWorkingDirectory();
+  
+  // Resolve the path to absolute, normalizing any .. or . components
+  const resolved = path.resolve(workDir, filePath);
+  
+  // Ensure the resolved path starts with the working directory
+  // This prevents escaping via ../ sequences
+  if (!resolved.startsWith(workDir + path.sep) && resolved !== workDir) {
+    return {
+      valid: false,
+      resolved,
+      error: `Path traversal rejected: ${filePath} resolves outside project directory`
+    };
+  }
+  
+  return { valid: true, resolved };
+}
+
 // Get communication directory
 // Supports session-specific directory via CLAUCODE_COMM_DIR environment variable
 // Falls back to legacy global directory for backwards compatibility
@@ -197,9 +224,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "nvim_edit_with_diff": {
       const { file_path, old_string, new_string } = EditFileSchema.parse(args);
       
+      // Validate path to prevent traversal attacks
+      const pathValidation = validateFilePath(file_path);
+      if (!pathValidation.valid) {
+        return {
+          content: [{
+            type: "text",
+            text: `Error: ${pathValidation.error}`
+          }]
+        };
+      }
+      const safePath = pathValidation.resolved;
+      
       try {
-        // Read current content
-        const content = await fs.readFile(file_path, "utf-8");
+        // Read current content using validated path
+        const content = await fs.readFile(safePath, "utf-8");
         
         // Check if old_string exists
         if (!content.includes(old_string)) {
@@ -215,10 +254,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const modified = content.replace(old_string, new_string);
         
         // Show diff and wait for approval
-        const approved = await showDiffAndWait(file_path, content, modified);
+        const approved = await showDiffAndWait(safePath, content, modified);
 
         if (approved) {
-          await fs.writeFile(file_path, modified, "utf-8");
+          await fs.writeFile(safePath, modified, "utf-8");
           return {
             content: [{
               type: "text",
@@ -233,11 +272,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }]
           };
         }
-      } catch (error: any) {
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
         return {
           content: [{
             type: "text",
-            text: `Error: ${error.message}`
+            text: `Error: ${message}`
           }]
         };
       }
@@ -246,21 +286,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "nvim_write_with_diff": {
       const { file_path, content } = WriteFileSchema.parse(args);
       
+      // Validate path to prevent traversal attacks
+      const pathValidation = validateFilePath(file_path);
+      if (!pathValidation.valid) {
+        return {
+          content: [{
+            type: "text",
+            text: `Error: ${pathValidation.error}`
+          }]
+        };
+      }
+      const safePath = pathValidation.resolved;
+      
       try {
         // Read current content if file exists
         let original = "";
         try {
-          original = await fs.readFile(file_path, "utf-8");
+          original = await fs.readFile(safePath, "utf-8");
         } catch {
-          // File doesn't exist
+          // File doesn't exist - that's okay for new files
         }
         
         // Show diff and wait for approval
-        const approved = await showDiffAndWait(file_path, original, content);
+        const approved = await showDiffAndWait(safePath, original, content);
         
         if (approved) {
-          await fs.mkdir(path.dirname(file_path), { recursive: true });
-          await fs.writeFile(file_path, content, "utf-8");
+          // Ensure parent directory exists (validated path is safe)
+          await fs.mkdir(path.dirname(safePath), { recursive: true });
+          await fs.writeFile(safePath, content, "utf-8");
           return {
             content: [{
               type: "text",
@@ -275,11 +328,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }]
           };
         }
-      } catch (error: any) {
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
         return {
           content: [{
             type: "text",
-            text: `Error: ${error.message}`
+            text: `Error: ${message}`
           }]
         };
       }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -303,8 +303,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         let original = "";
         try {
           original = await fs.readFile(safePath, "utf-8");
-        } catch {
-          // File doesn't exist - that's okay for new files
+        } catch (error) {
+          // File doesn't exist is fine, but rethrow other errors
+          if (!(error instanceof Error && (error as NodeJS.ErrnoException).code === 'ENOENT')) {
+            throw error;
+          }
         }
         
         // Show diff and wait for approval


### PR DESCRIPTION
Hey Avi,

I spent some time going through the claucode.nvim codebase and really enjoyed digging into how you structured the MCP bridge and the diff preview system - clever approach with the file-based IPC.

While exploring, I noticed a few spots that could use some hardening, mostly around shell command construction and path validation in the MCP server. Nothing was actively being exploited, but figured it would be good to tighten things up before they become a problem. I also took the opportunity to update some deprecated Neovim API calls to the modern equivalents since I was already in there.

All the changes are backward-compatible and should not break anything for existing users. The details are below if you want to take a look.

---

## Summary

This pull request addresses multiple security vulnerabilities and modernizes the codebase to use current Neovim API patterns. All changes preserve existing functionality while eliminating attack vectors and deprecation warnings.

## Security Fixes

### Critical: Shell Command Injection Prevention

**Files affected:** `lua/claucode/mcp.lua`, `lua/claucode/mcp_manager.lua`, `lua/claucode/terminal.lua`

**Issue:** Several locations used string concatenation to build shell commands, which could allow command injection if paths contained shell metacharacters.

**Before (vulnerable):**
```lua
local cmd = string.format("cd '%s' && npm install", mcp_dir)
vim.fn.system(cmd)
```

**After (safe):**
```lua
vim.fn.system({"npm", "install", "--prefix", mcp_dir})
```

**Changes:**
- `mcp.lua:build_mcp_server()` - Replaced `string.format("cd '%s' && npm install")` with array-form `vim.fn.system({"npm", "install", "--prefix", mcp_dir})`
- `mcp.lua:build_async()` - Replaced shell string in `vim.fn.jobstart({"sh", "-c", ...})` with direct array form
- `mcp_manager.lua:remove_mcp_server()` - Replaced `string.format("cd '%s' && %s mcp remove %s")` with array-form system call
- `terminal.lua:open_claude_terminal()` - Replaced string concatenation of CLI args with array tokenization

### Critical: Path Traversal Prevention in MCP Server

**File affected:** `mcp-server/src/index.ts`

**Issue:** The MCP server accepted `file_path` parameters from Claude without validation. A malicious or confused AI could write to files outside the project directory (e.g., `../../../etc/passwd` on Unix or `..\..\..\..\Windows\System32` on Windows).

**Fix:** Added `validateFilePath()` function that:
1. Resolves the path to absolute form (normalizing `..` components)
2. Verifies the resolved path starts with the project working directory
3. Rejects any path that escapes the project boundary

```typescript
function validateFilePath(filePath: string): { valid: boolean; resolved: string; error?: string } {
  const workDir = getWorkingDirectory();
  const resolved = path.resolve(workDir, filePath);
  
  if (!resolved.startsWith(workDir + path.sep) && resolved !== workDir) {
    return {
      valid: false,
      resolved,
      error: `Path traversal rejected: ${filePath} resolves outside project directory`
    };
  }
  
  return { valid: true, resolved };
}
```

Both `nvim_edit_with_diff` and `nvim_write_with_diff` handlers now validate paths before any file operations.

### Medium: Improved Error Handling in TypeScript

**File affected:** `mcp-server/src/index.ts`

**Issue:** Used `error: any` type annotation which defeats TypeScript's type safety.

**Fix:** Replaced with proper `instanceof Error` check:
```typescript
} catch (error) {
  const message = error instanceof Error ? error.message : "Unknown error";
  return { content: [{ type: "text", text: `Error: ${message}` }] };
}
```

## Code Quality Improvements

### Dead Code Removal

**File affected:** `lua/claucode/bridge.lua`

Removed unused `escape_prompt()` function that was defined but never called.

### Deprecated API Migration

**Files affected:** `lua/claucode/mcp.lua`, `lua/claucode/ui.lua`, `lua/claucode/terminal.lua`, `lua/claucode/watcher.lua`

Migrated from deprecated Neovim 0.9 APIs to modern equivalents:

| Deprecated API | Modern Replacement |
|----------------|-------------------|
| `vim.api.nvim_buf_set_option(buf, "opt", val)` | `vim.bo[buf].opt = val` |
| `vim.api.nvim_buf_get_option(buf, "opt")` | `vim.bo[buf].opt` |
| `vim.api.nvim_win_set_option(win, "opt", val)` | `vim.wo[win].opt = val` |

This eliminates deprecation warnings and follows current Neovim best practices.

### Cross-Platform Path Handling

**File affected:** `lua/claucode/session.lua`

**Issue:** Session ID generation used Unix-only path separator removal (`gsub("/$", "")`).

**Fix:** Updated to handle both Unix forward slashes and Windows backslashes:
```lua
cached_project_dir = cached_project_dir:gsub("[/\\]$", "")
```

## Files Changed

| File | Changes |
|------|---------|
| `lua/claucode/bridge.lua` | Removed dead code |
| `lua/claucode/mcp.lua` | Shell injection fix, deprecated API migration |
| `lua/claucode/mcp_manager.lua` | Shell injection fix |
| `lua/claucode/terminal.lua` | Command injection fix, deprecated API migration |
| `lua/claucode/ui.lua` | Deprecated API migration |
| `lua/claucode/watcher.lua` | Deprecated API migration |
| `lua/claucode/session.lua` | Cross-platform path handling |
| `mcp-server/src/index.ts` | Path traversal prevention, type safety |

## Testing Notes

All changes are backward-compatible. To verify:

1. **MCP server build**: Run `:checkhealth claucode` - should show MCP server as built
2. **Terminal functionality**: Run `:ClaudeTerminal` - should open Claude in split
3. **Diff preview**: Enable with `show_diff = true` and test file edits through Claude
4. **Path validation**: The MCP server will reject any file paths containing `..` that escape the project

## Breaking Changes

None. All public APIs remain unchanged.

## Security Considerations Post-Merge

- The diff preview system still requires user approval for all file changes (defense in depth)
- IPC files in `~/.local/share/claucode/diffs/` are created with default permissions; consider adding explicit `0600` mode in future
- Session isolation uses SHA256 hash of project path for uniqueness, not for cryptographic security
