### PR TITLE
feat: v0.3.1 refresh + runtime auto-accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## v0.3.1 — 2026-05-01
+
+### Added
+- **`:ClaudeAutoAccept [on|off]`** — runtime passthrough flag. When enabled, the MCP server writes files immediately without showing the diff UI. Takes effect on the very next tool call; no Claude session restart, no `CLAUDE.md` changes. Useful for autonomous runs. Cleared on Neovim exit.
+- `bridge.auto_accept = false` config option to start a session with passthrough already on.
+- `lua/claucode/health.lua` — proper `:checkhealth claucode` support (module is loaded lazily by Neovim's health framework, so it now reports even before `setup()` has run).
+
+### Changed
+- **Flagship feature is on by default:** `bridge.show_diff` now defaults to `true`. If you relied on the old default, set it to `false` in your config.
+- Minimum Neovim bumped to **0.10** (`vim.system`, `vim.uv`, modern `vim.health`). A friendly error replaces the silent failure on older versions.
+- Replaced blocking `io.popen` CLI detection with non-blocking `vim.system` — faster startup on slow filesystems.
+- Normalized `vim.loop` to `vim.uv` throughout (`vim.loop` is deprecated since 0.10).
+- Dropped the hardcoded `claude-sonnet-4-20250514` model SKU in defaults. The Claude CLI chooses its own default now; override via your config if you need a specific model.
+
+### Removed
+- Old `M.health()` function on the main module — replaced by `lua/claucode/health.lua`.
+
+## v0.3.0
+
+Initial MCP diff preview, multi-session support, interactive `:Claude` prompt, notification controls. See git history.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ A lightweight Neovim plugin that bridges your editor with Claude Code CLI, bring
 
 ### Prerequisites
 
-- Neovim 0.5 or later
+- Neovim 0.10 or later (uses `vim.system`, `vim.uv`, and modern `vim.health`)
 - [Claude Code CLI](https://claude.ai/code) (`npm install -g @anthropic-ai/claude-code`)
-- `ANTHROPIC_API_KEY` environment variable or connected using another login method
+- `ANTHROPIC_API_KEY` environment variable or a logged-in Claude CLI session
+- Node.js + npm (only needed if the MCP server has to be built locally)
 
 ### Installation
 
@@ -209,13 +210,34 @@ This command will:
 
 **Note:** Diff preview requires `mcp.enabled = true` in your configuration. If MCP is disabled, the toggle command will show a warning.
 
+### Auto-accept (runtime passthrough)
+
+Sometimes you want Claude to just *apply* edits without the review step — e.g. during an autonomous run. Toggle it mid-session, no restart required:
+
+```vim
+:ClaudeAutoAccept          " flip current state
+:ClaudeAutoAccept on       " explicitly enable
+:ClaudeAutoAccept off      " explicitly disable (back to diff preview)
+```
+
+Or set it at startup:
+
+```lua
+require("claucode").setup({
+  bridge = { auto_accept = true },
+})
+```
+
+Unlike `:ClaudeDiffToggle`, this does **not** tear down the MCP server or rewrite `CLAUDE.md`. The very next `nvim_edit_with_diff` / `nvim_write_with_diff` call will honor the new state. The flag is cleared automatically when Neovim exits.
+
 ### Commands
 
 - `:Claude [prompt]` - Send a prompt to Claude (shows response in popup). Without arguments, opens an input prompt.
 - `:Claude --file <prompt>` - Include current file context with prompt
 - `:ClaudeTerminal [cli_args]` - Open Claude in a terminal split with optional CLI parameters
 - `:ClaudeTerminalToggle` - Toggle Claude terminal visibility
-- `:ClaudeDiffToggle` - Toggle diff preview on/off
+- `:ClaudeDiffToggle` - Toggle diff preview on/off (tears down MCP; requires Claude session restart)
+- `:ClaudeAutoAccept [on|off]` - Toggle MCP auto-accept (passthrough); takes effect on the next tool call
 
 ### Default Keymaps
 

--- a/lua/claucode/bridge.lua
+++ b/lua/claucode/bridge.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local current_process = nil
 local current_stdin = nil
 local output_buffer = ""

--- a/lua/claucode/health.lua
+++ b/lua/claucode/health.lua
@@ -13,7 +13,7 @@ local function run_version(cmd)
 	local ok, result = pcall(vim.system, { cmd, "--version" }, { text = true, timeout = 2000 })
 	if not ok or not result then return nil end
 	local done = result:wait(2000)
-	if done.code ~= 0 then return nil end
+	if not done or done.code ~= 0 then return nil end
 	return vim.trim((done.stdout or "") .. (done.stderr or ""))
 end
 

--- a/lua/claucode/health.lua
+++ b/lua/claucode/health.lua
@@ -1,0 +1,90 @@
+-- Health check for :checkhealth claucode
+--
+-- Neovim discovers this file automatically via `lua/<plugin>/health.lua`,
+-- so callers don't need to load the main module first.
+
+local M = {}
+
+local function has_exec(bin)
+	return vim.fn.executable(bin) == 1
+end
+
+local function run_version(cmd)
+	local ok, result = pcall(vim.system, { cmd, "--version" }, { text = true, timeout = 2000 })
+	if not ok or not result then return nil end
+	local done = result:wait(2000)
+	if done.code ~= 0 then return nil end
+	return vim.trim((done.stdout or "") .. (done.stderr or ""))
+end
+
+function M.check()
+	local health = vim.health
+	health.start("claucode.nvim")
+
+	-- Neovim version
+	if vim.fn.has("nvim-0.10") == 1 then
+		health.ok("Neovim " .. tostring(vim.version()))
+	else
+		health.error("Neovim 0.10+ required (current: " .. tostring(vim.version()) .. ")")
+	end
+
+	-- Main module loaded
+	local mod_ok, main = pcall(require, "claucode")
+	if not mod_ok then
+		health.error("claucode module failed to load: " .. tostring(main))
+		return
+	end
+	local cfg = main.config or {}
+
+	-- Claude CLI
+	local claude_cmd = cfg.command or "claude"
+	if has_exec(claude_cmd) then
+		health.ok("Claude Code CLI found: " .. claude_cmd)
+		local version = run_version(claude_cmd)
+		if version then
+			health.ok("Claude Code CLI version: " .. version)
+		else
+			health.warn("Claude Code CLI reachable but --version failed")
+		end
+	else
+		health.error(
+			"Claude Code CLI not found",
+			{ "Install: npm install -g @anthropic-ai/claude-code" }
+		)
+	end
+
+	-- Auth: ANTHROPIC_API_KEY OR `claude` has logged-in creds
+	if vim.env.ANTHROPIC_API_KEY and vim.env.ANTHROPIC_API_KEY ~= "" then
+		health.ok("ANTHROPIC_API_KEY is set")
+	else
+		health.info("ANTHROPIC_API_KEY not set (expected if you authenticated via `claude login`)")
+	end
+
+	-- MCP server
+	if (cfg.mcp or {}).enabled then
+		local plugin_root = debug.getinfo(1, "S").source:sub(2):match("(.*/lua/claucode/).+") or ""
+		plugin_root = plugin_root:gsub("/lua/claucode/$", "")
+		local bundled = plugin_root .. "/mcp-server/build/index.js"
+		local user_built = vim.fn.expand("~/.config/claucode/mcp-server/build/index.js")
+		if vim.fn.filereadable(bundled) == 1 then
+			health.ok("MCP server (bundled): " .. bundled)
+		elseif vim.fn.filereadable(user_built) == 1 then
+			health.ok("MCP server (user): " .. user_built)
+		else
+			health.warn("MCP server not built yet (auto-builds on first use)")
+		end
+	else
+		health.info("MCP disabled in config; diff preview unavailable")
+	end
+
+	-- Toolchain
+	for _, tool in ipairs({ "git", "node", "npm" }) do
+		if has_exec(tool) then
+			health.ok(tool .. ": available")
+		else
+			health.warn(tool .. " not found (required for MCP server build)")
+		end
+	end
+end
+
+return M

--- a/lua/claucode/init.lua
+++ b/lua/claucode/init.lua
@@ -136,7 +136,7 @@ local function find_claude_command()
 			local ok, proc = pcall(vim.system, { path, "--version" }, { text = true, timeout = 2000 })
 			if ok and proc then
 				local result = proc:wait(2000)
-				if result.code == 0 and (result.stdout or ""):match("Claude Code") then
+				if result and result.code == 0 and (result.stdout or ""):match("Claude Code") then
 					return path
 				end
 			end
@@ -209,7 +209,7 @@ function M.setup(user_config)
 					require("claucode.mcp").cleanup()
 				end
 				-- Always clear the passthrough flag on exit
-				pcall(set_passthrough, false)
+				M.set_auto_accept(false)
 				-- Remove MCP server if cleanup_on_exit is enabled
 				if M.config.mcp.cleanup_on_exit ~= false then
 					require("claucode.mcp_manager").remove_mcp_server()
@@ -220,10 +220,10 @@ function M.setup(user_config)
 
 		-- Honor initial config.bridge.auto_accept
 		if M.config.bridge.auto_accept then
-			set_passthrough(true)
+			M.set_auto_accept(true)
 		else
 			-- Clear any stale flag from a previous crashed session
-			set_passthrough(false)
+			M.set_auto_accept(false)
 		end
 	end
 
@@ -286,7 +286,7 @@ function M.setup(user_config)
 		else
 			target = not M.config.bridge.auto_accept
 		end
-		set_passthrough(target)
+		M.set_auto_accept(target)
 		if target then
 			notify.info("Claucode auto-accept ON — MCP writes bypass the diff UI")
 		else

--- a/lua/claucode/init.lua
+++ b/lua/claucode/init.lua
@@ -2,19 +2,17 @@
 -- Repository: https://github.com/avifenesh/claucode.nvim
 -- License: MIT
 -- Author: Avi Fenesh
--- Version: 0.3.0
 
 local M = {
-	-- Plugin version
-	version = "0.3.0",
+	version = "0.3.1",
 }
 
 -- Default configuration
 M.config = {
-	-- Claude Code CLI command
+	-- Claude Code CLI command (looked up on PATH by default)
 	command = "claude",
-	-- Default model to use
-	model = "claude-sonnet-4-20250514",
+	-- Model override: nil = let the Claude Code CLI pick its default
+	model = nil,
 	-- Auto-start file watcher on setup
 	auto_start_watcher = true,
 	-- Enable default keymaps
@@ -74,10 +72,15 @@ M.config = {
 		timeout = 30000,
 		-- Max output buffer size
 		max_output = 1048576, -- 1MB
-		-- Show diff before applying changes (requires MCP)
-		show_diff = false,
+		-- Show diff before applying changes (requires MCP). Flagship feature — on by default.
+		show_diff = true,
 		-- Automatically add diff instructions to CLAUDE.md
 		auto_claude_md = true,
+		-- Auto-accept (passthrough): if true, the MCP server writes files
+		-- immediately without prompting in Neovim. Toggle at runtime with
+		-- :ClaudeAutoAccept — takes effect on the very next tool call, no
+		-- Claude session restart required.
+		auto_accept = false,
 	},
 	-- MCP settings
 	mcp = {
@@ -128,14 +131,12 @@ local function find_claude_command()
 	}
 
 	for _, path in ipairs(common_paths) do
-		-- Check if file exists and is readable
-		if vim.fn.filereadable(path) == 1 then
-			-- Test if we can actually run it
-			local handle = io.popen(path .. " --version 2>&1")
-			if handle then
-				local result = handle:read("*a")
-				handle:close()
-				if result:match("Claude Code") then
+		if vim.fn.filereadable(path) == 1 and vim.fn.executable(path) == 1 then
+			-- Non-blocking spawn; 2s timeout is plenty for --version
+			local ok, proc = pcall(vim.system, { path, "--version" }, { text = true, timeout = 2000 })
+			if ok and proc then
+				local result = proc:wait(2000)
+				if result.code == 0 and (result.stdout or ""):match("Claude Code") then
 					return path
 				end
 			end
@@ -159,6 +160,15 @@ local function merge_config(user_config)
 end
 
 function M.setup(user_config)
+	-- Neovim version guard: we rely on vim.system (0.10+) and vim.health (0.10+)
+	if vim.fn.has("nvim-0.10") ~= 1 then
+		vim.notify(
+			"claucode.nvim requires Neovim 0.10+ (current: " .. tostring(vim.version()) .. ")",
+			vim.log.levels.ERROR
+		)
+		return
+	end
+
 	merge_config(user_config)
 
 	-- Validate configuration
@@ -198,6 +208,8 @@ function M.setup(user_config)
 				if M.config.bridge.show_diff then
 					require("claucode.mcp").cleanup()
 				end
+				-- Always clear the passthrough flag on exit
+				pcall(set_passthrough, false)
 				-- Remove MCP server if cleanup_on_exit is enabled
 				if M.config.mcp.cleanup_on_exit ~= false then
 					require("claucode.mcp_manager").remove_mcp_server()
@@ -205,6 +217,14 @@ function M.setup(user_config)
 			end,
 			desc = "Claucode cleanup on exit"
 		})
+
+		-- Honor initial config.bridge.auto_accept
+		if M.config.bridge.auto_accept then
+			set_passthrough(true)
+		else
+			-- Clear any stale flag from a previous crashed session
+			set_passthrough(false)
+		end
 	end
 
 	-- Setup CLAUDE.md management for diff preview
@@ -255,6 +275,29 @@ function M.setup(user_config)
 
 
 
+	vim.api.nvim_create_user_command("ClaudeAutoAccept", function(opts)
+		local notify = require("claucode.notify")
+		local arg = vim.trim(opts.args or ""):lower()
+		local target
+		if arg == "on" or arg == "true" or arg == "1" then
+			target = true
+		elseif arg == "off" or arg == "false" or arg == "0" then
+			target = false
+		else
+			target = not M.config.bridge.auto_accept
+		end
+		set_passthrough(target)
+		if target then
+			notify.info("Claucode auto-accept ON — MCP writes bypass the diff UI")
+		else
+			notify.info("Claucode auto-accept OFF — diff UI will prompt again")
+		end
+	end, {
+		nargs = "?",
+		complete = function() return { "on", "off" } end,
+		desc = "Toggle MCP auto-accept (passthrough). Runtime switch; no session restart.",
+	})
+
 	vim.api.nvim_create_user_command("ClaudeDiffToggle", function()
 		local notify = require("claucode.notify")
 		-- Toggle the show_diff configuration
@@ -298,77 +341,25 @@ function M.get_config()
 	return M.config
 end
 
--- Health check function for :checkhealth
-function M.health()
-	local health = vim.health or require("health")
-	local start = health.start or health.report_start
-	local ok = health.ok or health.report_ok
-	local warn = health.warn or health.report_warn
-	local error = health.error or health.report_error
-	
-	start("claucode.nvim")
-	
-	-- Check Neovim version
-	if vim.fn.has("nvim-0.5.0") == 1 then
-		ok("Neovim version >= 0.5.0")
+-- Set the MCP passthrough flag. When on, the MCP server writes files
+-- immediately without asking Neovim — effect is picked up by the very next
+-- tool call. No Claude session restart, no CLAUDE.md changes.
+local function set_passthrough(enabled)
+	local comm_dir = require("claucode.session").get_communication_dir()
+	vim.fn.mkdir(comm_dir, "p")
+	local flag = comm_dir .. "/passthrough.flag"
+	if enabled then
+		vim.fn.writefile({ tostring(os.time()) }, flag)
 	else
-		error("Neovim version < 0.5.0. Please upgrade Neovim.")
-	end
-	
-	-- Check Claude CLI
-	local claude_cmd = M.config.command or "claude"
-	if vim.fn.executable(claude_cmd) == 1 then
-		ok("Claude Code CLI found: " .. claude_cmd)
-		
-		-- Check version
-		local handle = io.popen(claude_cmd .. " --version 2>&1")
-		if handle then
-			local version = handle:read("*a")
-			handle:close()
-			if version and version:match("Claude Code") then
-				ok("Claude Code CLI version: " .. version:gsub("\n", ""))
-			end
-		end
-	else
-		error("Claude Code CLI not found. Install with: npm install -g @anthropic-ai/claude-code")
-	end
-	
-	-- Check API key
-	if vim.fn.getenv("ANTHROPIC_API_KEY") ~= vim.NIL then
-		ok("ANTHROPIC_API_KEY is set")
-	else
-		warn("ANTHROPIC_API_KEY not set. You may need to authenticate via other methods.")
-	end
-	
-	-- Check MCP server if enabled
-	if M.config.mcp.enabled then
-		local mcp_server_path = vim.fn.expand("~/.config/claucode/mcp-server/build/index.js")
-		if vim.fn.filereadable(mcp_server_path) == 1 then
-			ok("MCP server built and ready")
-		else
-			warn("MCP server not built. Will be built on first use.")
+		if vim.fn.filereadable(flag) == 1 then
+			os.remove(flag)
 		end
 	end
-	
-	-- Check Git (for diff functionality)
-	if vim.fn.executable("git") == 1 then
-		ok("Git is installed")
-	else
-		warn("Git not found. Diff functionality may be limited.")
-	end
-	
-	-- Check Node.js and npm (for MCP)
-	if vim.fn.executable("node") == 1 then
-		ok("Node.js is installed")
-	else
-		warn("Node.js not found. Required for MCP server.")
-	end
-	
-	if vim.fn.executable("npm") == 1 then
-		ok("npm is installed")
-	else
-		warn("npm not found. Required for installing Claude CLI and building MCP server.")
-	end
+	M.config.bridge.auto_accept = enabled
+end
+
+function M.set_auto_accept(enabled)
+	set_passthrough(enabled and true or false)
 end
 
 -- Utility function to get plugin status
@@ -403,7 +394,7 @@ function M.debug_info()
 		config = M.config,
 		status = M.status(),
 		nvim_version = vim.version().major .. "." .. vim.version().minor .. "." .. vim.version().patch,
-		os = vim.loop.os_uname().sysname,
+		os = (vim.uv or vim.loop).os_uname().sysname,
 		cwd = vim.fn.getcwd(),
 	}
 	

--- a/lua/claucode/mcp.lua
+++ b/lua/claucode/mcp.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local mcp_process = nil
 local pending_diffs = {}
 

--- a/lua/claucode/watcher.lua
+++ b/lua/claucode/watcher.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local watchers = {}
 local file_timestamps = {}
 local debounce_timers = {}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -52,6 +52,19 @@ async function ensureCommunicationDir(): Promise<string> {
   return dir;
 }
 
+// Runtime auto-accept (passthrough) flag. When set, tool calls skip the
+// Neovim round-trip entirely and write immediately. Controlled by the Lua
+// side via :ClaudeAutoAccept / bridge.auto_accept config.
+async function isPassthroughActive(): Promise<boolean> {
+  try {
+    const dir = getCommunicationDir();
+    await fs.access(path.join(dir, "passthrough.flag"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Create hash for diff identification
 function createDiffHash(filepath: string, original: string, modified: string): string {
   return createHash('sha256')
@@ -196,12 +209,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   switch (name) {
     case "nvim_edit_with_diff": {
       const { file_path, old_string, new_string } = EditFileSchema.parse(args);
-      
+
       try {
-        // Read current content
         const content = await fs.readFile(file_path, "utf-8");
-        
-        // Check if old_string exists
+
         if (!content.includes(old_string)) {
           return {
             content: [{
@@ -210,11 +221,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }]
           };
         }
-        
-        // Create modified content
+
         const modified = content.replace(old_string, new_string);
-        
-        // Show diff and wait for approval
+
+        // Runtime passthrough: auto-accept without round-tripping to Neovim
+        if (await isPassthroughActive()) {
+          await fs.writeFile(file_path, modified, "utf-8");
+          return {
+            content: [{
+              type: "text",
+              text: `Successfully edited ${file_path} (auto-accepted)`
+            }]
+          };
+        }
+
         const approved = await showDiffAndWait(file_path, content, modified);
 
         if (approved) {
@@ -242,22 +262,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
     }
-    
+
     case "nvim_write_with_diff": {
       const { file_path, content } = WriteFileSchema.parse(args);
-      
+
       try {
-        // Read current content if file exists
         let original = "";
         try {
           original = await fs.readFile(file_path, "utf-8");
         } catch {
           // File doesn't exist
         }
-        
-        // Show diff and wait for approval
+
+        // Runtime passthrough: auto-accept without round-tripping to Neovim
+        if (await isPassthroughActive()) {
+          await fs.mkdir(path.dirname(file_path), { recursive: true });
+          await fs.writeFile(file_path, content, "utf-8");
+          return {
+            content: [{
+              type: "text",
+              text: `Successfully wrote ${file_path} (auto-accepted)`
+            }]
+          };
+        }
+
         const approved = await showDiffAndWait(file_path, original, content);
-        
+
         if (approved) {
           await fs.mkdir(path.dirname(file_path), { recursive: true });
           await fs.writeFile(file_path, content, "utf-8");


### PR DESCRIPTION
## Summary

First PR of the v0.3.x revival series — modernizes the plugin and adds one new feature: runtime auto-accept without a Claude session restart.

### New: `:ClaudeAutoAccept [on|off]`

Flipping this toggles a flag file that the MCP server checks on every tool call. When on, `nvim_edit_with_diff` / `nvim_write_with_diff` just write the file immediately — no diff UI, no `CLAUDE.md` rewrite, no Claude session restart. Takes effect on the very next tool call. Cleared on `VimLeavePre`, and stale flags from crashed sessions are wiped on `setup()`.

Why: `:ClaudeDiffToggle` tears down the MCP registration, which required restarting the Claude session. Wrong layer. The runtime switch belongs inside the server that every tool call already passes through.

```vim
:ClaudeAutoAccept          " flip current state
:ClaudeAutoAccept on       " explicitly enable
:ClaudeAutoAccept off      " explicitly disable
```

```lua
require("claucode").setup({ bridge = { auto_accept = true } })
```

### Also in this refresh

- **Health check moved** to `lua/claucode/health.lua` — Neovim's health framework discovers it automatically now, so `:checkhealth claucode` reports even before `setup()` has run.
- **Min Neovim bumped to 0.10** with a friendly runtime guard. Enables `vim.system`, `vim.uv`, modern `vim.health`.
- **`io.popen` → `vim.system`** in the Claude CLI auto-detect path — no more blocking startup on slow filesystems.
- **`vim.loop` → `vim.uv`** throughout (deprecated alias).
- **Dropped hardcoded `claude-sonnet-4-20250514`** default. Claude CLI picks its own default model; override via config if needed.
- **`bridge.show_diff` default flipped to `true`** — the flagship feature is now on out of the box. Old default available by setting to `false`.

## Test plan

- [x] `:checkhealth claucode` reports clean on Neovim 0.12.2
- [x] Plugin loads via LazyVim spec (`dir = ~/projects/claucode.nvim`, `dev = true`)
- [x] MCP server rebuilds (`npm run build` in `mcp-server/`)
- [ ] Confirm `:ClaudeAutoAccept on` followed by a fresh `:Claude` prompt writes without showing the diff window
- [ ] Confirm `:ClaudeAutoAccept off` restores diff preview on the next tool call
- [ ] Confirm flag file cleaned up on `:qa`

No unit tests in the repo yet — small Lua plugin, manual verification above.

## Follow-ups (separate PRs)

- **Phase 2:** inline editing mode (`:ClaudeInline`) with streamed ghost-text.
- **Phase 3:** extract `claucode-core` for reuse by a sibling `codex.nvim` plugin.
- **CI:** release workflow that bundles `mcp-server/build/` as an asset so first-launch skips the npm install.

No release tag with this PR — hold until the build-asset CI lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)